### PR TITLE
Headingを「render」で実装

### DIFF
--- a/stories/components/heading/aoken0714/SecondHeading.stories.js
+++ b/stories/components/heading/aoken0714/SecondHeading.stories.js
@@ -4,7 +4,7 @@ export default {
   title: "Example/Heading/aoken0714",
   component: Heading,
   argTypes: {
-    level: { control: { type: "select", options: [1, 2, 3] } },
+    level: { control: { type: "select", options: [1, 2, 3, 4, 5, 6] } },
   },
 };
 

--- a/stories/components/heading/aoken0714/SecondHeading.stories.js
+++ b/stories/components/heading/aoken0714/SecondHeading.stories.js
@@ -1,0 +1,20 @@
+import Heading from "./SecondHeading.vue";
+
+export default {
+  title: "Example/Heading/aoken0714",
+  component: Heading,
+  argTypes: {
+    level: { control: { type: "select", options: [1, 2, 3] } },
+  },
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { Heading },
+  template: '<heading v-bind="$props" >見出しをrenderで作成</heading>',
+});
+
+export const Headings = Template.bind({});
+Headings.args = {
+  level: 1,
+};

--- a/stories/components/heading/aoken0714/SecondHeading.vue
+++ b/stories/components/heading/aoken0714/SecondHeading.vue
@@ -8,7 +8,7 @@ export default {
       type: Number,
       required: true,
       validator: function (value) {
-        return [1, 2, 3].includes(value);
+        return [1, 2, 3, 4, 5, 6].includes(value);
       },
     },
   },

--- a/stories/components/heading/aoken0714/SecondHeading.vue
+++ b/stories/components/heading/aoken0714/SecondHeading.vue
@@ -1,0 +1,16 @@
+<script>
+export default {
+  render: function (createElement) {
+    return createElement("h" + this.level, this.$slots.default);
+  },
+  props: {
+    level: {
+      type: Number,
+      required: true,
+      validator: function (value) {
+        return [1, 2, 3].includes(value);
+      },
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## 概要
- 関連Issue: #34
- [Vueのガイド](https://jp.vuejs.org/v2/guide/render-function.html)にHeadingの実装例があったので模倣
  - あまりUIは頑張ってません、、、
## 仕様
- コンポーネントを使用する側が、見出しのレベルを決定できる